### PR TITLE
Fix lints reported by clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 use std::ffi::CString;
 use std::os::unix::io::RawFd;
 
-#[no_mangle]
 extern "C" {
     fn launch_activate_socket(
         name: *const libc::c_char,
@@ -60,10 +59,7 @@ pub fn activate_socket(name: &str) -> Result<Vec<RawFd>, Error> {
         unknown => return Err(Error::Unknown(unknown)),
     };
 
-    let out = unsafe {
-        let slice = std::slice::from_raw_parts(fds, cnt);
-        slice.iter().copied().collect::<Vec<RawFd>>()
-    };
+    let out = unsafe { std::slice::from_raw_parts(fds, cnt).to_vec() };
 
     unsafe {
         libc::free(fds as *mut _);


### PR DESCRIPTION
The `no_mangle` caused a lint error:

```
error: attribute should be applied to a free function, impl method or static
  --> src/lib.rs:7:1
   |
7  |   #[no_mangle]
   |   ^^^^^^^^^^^^
8  | / extern "C" {
9  | |     fn launch_activate_socket(
10 | |         name: *const libc::c_char,
11 | |         fds: *mut *mut libc::c_int,
12 | |         cnt: *mut libc::size_t,
13 | |     ) -> libc::c_int;
14 | | }
   | |_- not a free function, impl method or static
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
```