### PR TITLE
Add more metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A safe wrapper around launchd launch_activate_socket"
 repository = "https://github.com/bbqsrc/raunch"
+keywords = ["macos", "launchd", "socket", "activation"]
+categories = ["os::macos-apis"]
 
 [dependencies]
 libc = "0.2.69"


### PR DESCRIPTION
I don't have an strong opinion on this but it might be a good idea to update the edition to 2021.

Another thing I'd add is a link to https://crates.io/crates/raunch on the Github project page (https://github.com/bbqsrc/raunch; I think there's this cog icon on the right)